### PR TITLE
feat: ROAD-860: Add spawn and env options to sdk.exec

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,9 +6,13 @@ import { Interfaces } from './types'
 
 const pExec = util.promisify(childProcess.exec)
 
+export interface Env {
+  [key: string]: string | undefined
+}
+
 export interface ExecOptions {
   spawn?: boolean
-  env?: any
+  env?: Env
 }
 
 export async function exec(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -6,10 +6,24 @@ import { Interfaces } from './types'
 
 const pExec = util.promisify(childProcess.exec)
 
+export interface ExecOptions {
+  spawn?: boolean
+  env?: any
+}
+
 export async function exec(
   command: string,
-): Promise<{ stdout: string; stderr: string }> {
-  return await pExec(command)
+  options: ExecOptions = {},
+): Promise<{ stdout: string; stderr: string } | childProcess.ChildProcess> {
+  const childEnv = options.env
+    ? { ...options.env, ...process.env }
+    : process.env
+
+  if (options.spawn) {
+    return childProcess.spawn(command, { env: childEnv, shell: true })
+  } else {
+    return await pExec(command, { env: childEnv })
+  }
 }
 
 export function getHostOS(): string {


### PR DESCRIPTION
This MR allows the user of `sdk.exec` to select a streaming I/O interface for the child process by adding the `spawn: true` option to the function call. It also allows additional environment variables to be passed in the options object; this method has fewer pitfalls and edge cases than the current approach of prefixing the command with `ENV=value` pairs.